### PR TITLE
Submit patch for writing synchronous debug line when uart overrun occurs

### DIFF
--- a/recipes-kernel/linux/files/0016-remove-debug-log-uart-overrun-error.patch
+++ b/recipes-kernel/linux/files/0016-remove-debug-log-uart-overrun-error.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/tty/serial/imx.c b/drivers/tty/serial/imx.c
+index c9bd603d395b..79acc2c6061b 100644
+--- a/drivers/tty/serial/imx.c
++++ b/drivers/tty/serial/imx.c
+@@ -756,7 +756,6 @@ static irqreturn_t imx_int(int irq, void *dev_id)
+ 		writel(USR1_AWAKE, sport->port.membase + USR1);
+ 
+ 	if (sts2 & USR2_ORE) {
+-		dev_err(sport->port.dev, "Rx FIFO overrun\n");
+ 		sport->port.icount.overrun++;
+ 		writel(USR2_ORE, sport->port.membase + USR2);
+ 	}


### PR DESCRIPTION
Fixes issue with uart and Rx FIFO overruns. See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/tty/serial/imx.c?id=e9b5a9825f6b02a9cf86697bcffafd3d7898f9f6 for more information.